### PR TITLE
Migrate all test files from JavaScript to TypeScript

### DIFF
--- a/__tests__/components/AuthDetails.test.tsx
+++ b/__tests__/components/AuthDetails.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
@@ -5,7 +6,7 @@ const mockSignOut = vi.fn(() => Promise.resolve())
 const mockOnAuthStateChanged = vi.fn()
 
 vi.mock('firebase/auth', () => ({
-  onAuthStateChanged: (...args) => mockOnAuthStateChanged(...args),
+  onAuthStateChanged: (...args: unknown[]) => mockOnAuthStateChanged(...args),
   signOut: () => mockSignOut(),
 }))
 
@@ -26,7 +27,7 @@ describe('AuthDetails', () => {
   })
 
   it('should show signed out state when no user', async () => {
-    mockOnAuthStateChanged.mockImplementation((auth, callback) => {
+    mockOnAuthStateChanged.mockImplementation((auth: unknown, callback: (user: null) => void) => {
       callback(null)
       return vi.fn()
     })
@@ -37,7 +38,7 @@ describe('AuthDetails', () => {
   })
 
   it('should show user email when signed in', async () => {
-    mockOnAuthStateChanged.mockImplementation((auth, callback) => {
+    mockOnAuthStateChanged.mockImplementation((auth: unknown, callback: (user: { email: string }) => void) => {
       callback({ email: 'test@example.com' })
       return vi.fn()
     })
@@ -50,7 +51,7 @@ describe('AuthDetails', () => {
   })
 
   it('should render sign out button when user is authenticated', async () => {
-    mockOnAuthStateChanged.mockImplementation((auth, callback) => {
+    mockOnAuthStateChanged.mockImplementation((auth: unknown, callback: (user: { email: string }) => void) => {
       callback({ email: 'test@example.com' })
       return vi.fn()
     })
@@ -63,7 +64,7 @@ describe('AuthDetails', () => {
   })
 
   it('should call signOut when sign out button is clicked', async () => {
-    mockOnAuthStateChanged.mockImplementation((auth, callback) => {
+    mockOnAuthStateChanged.mockImplementation((auth: unknown, callback: (user: { email: string }) => void) => {
       callback({ email: 'test@example.com' })
       return vi.fn()
     })
@@ -80,7 +81,7 @@ describe('AuthDetails', () => {
   })
 
   it('should not show sign out button when signed out', async () => {
-    mockOnAuthStateChanged.mockImplementation((auth, callback) => {
+    mockOnAuthStateChanged.mockImplementation((auth: unknown, callback: (user: null) => void) => {
       callback(null)
       return vi.fn()
     })

--- a/__tests__/components/Card.test.tsx
+++ b/__tests__/components/Card.test.tsx
@@ -1,12 +1,17 @@
+import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 vi.mock('next/image', () => ({
-  default: ({ src, alt, ...props }) => <img src={src} alt={alt} {...props} />,
+  default: ({ src, alt, ...props }: { src: string; alt: string; [key: string]: unknown }) => (
+    <img src={src} alt={alt} {...props} />
+  ),
 }))
 
 vi.mock('next/link', () => ({
-  default: ({ children, href }) => <a href={href}>{children}</a>,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
 }))
 
 vi.mock('next/font/google', () => ({
@@ -16,8 +21,17 @@ vi.mock('next/font/google', () => ({
 
 import Card from '../../components/Card'
 
+interface CardProps {
+  movieId: number
+  title: string
+  overview: string
+  poster_path: string
+  release_date: string
+  vote_average: number
+}
+
 describe('Card', () => {
-  const mockProps = {
+  const mockProps: CardProps = {
     movieId: 123,
     title: 'Skyfall',
     overview: 'James Bond investigates an attack on MI6.',

--- a/__tests__/components/Footer.test.tsx
+++ b/__tests__/components/Footer.test.tsx
@@ -1,8 +1,9 @@
+import React from 'react'
 import { describe, it, expect, vi } from 'vitest'
 import { render, screen } from '@testing-library/react'
 
 vi.mock('next/link', () => ({
-  default: ({ children, href, target }) => (
+  default: ({ children, href, target }: { children: React.ReactNode; href: string; target?: string }) => (
     <a href={href} target={target}>{children}</a>
   ),
 }))

--- a/__tests__/components/Navbar.test.tsx
+++ b/__tests__/components/Navbar.test.tsx
@@ -1,8 +1,11 @@
+import React from 'react'
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { render, screen, waitFor } from '@testing-library/react'
+import { render, screen } from '@testing-library/react'
 
 vi.mock('next/link', () => ({
-  default: ({ children, href }) => <a href={href}>{children}</a>,
+  default: ({ children, href }: { children: React.ReactNode; href: string }) => (
+    <a href={href}>{children}</a>
+  ),
 }))
 
 vi.mock('next/font/google', () => ({

--- a/__tests__/components/SignIn.test.tsx
+++ b/__tests__/components/SignIn.test.tsx
@@ -1,3 +1,4 @@
+import React from 'react'
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { render, screen, fireEvent, waitFor } from '@testing-library/react'
 
@@ -5,7 +6,7 @@ const mockPush = vi.fn()
 const mockSignInWithEmailAndPassword = vi.fn()
 
 vi.mock('firebase/auth', () => ({
-  signInWithEmailAndPassword: (...args) => mockSignInWithEmailAndPassword(...args),
+  signInWithEmailAndPassword: (...args: unknown[]) => mockSignInWithEmailAndPassword(...args),
 }))
 
 vi.mock('../../lib/db', () => ({
@@ -38,7 +39,7 @@ describe('SignIn', () => {
   it('should update email field on input', () => {
     render(<SignIn />)
 
-    const emailInput = screen.getByPlaceholderText('Email...')
+    const emailInput = screen.getByPlaceholderText('Email...') as HTMLInputElement
     fireEvent.change(emailInput, { target: { value: 'test@example.com' } })
 
     expect(emailInput.value).toBe('test@example.com')
@@ -47,7 +48,7 @@ describe('SignIn', () => {
   it('should update password field on input', () => {
     render(<SignIn />)
 
-    const passwordInput = screen.getByPlaceholderText('Password...')
+    const passwordInput = screen.getByPlaceholderText('Password...') as HTMLInputElement
     fireEvent.change(passwordInput, { target: { value: 'password123' } })
 
     expect(passwordInput.value).toBe('password123')

--- a/__tests__/lib/context.test.tsx
+++ b/__tests__/lib/context.test.tsx
@@ -1,7 +1,11 @@
 import { describe, it, expect } from 'vitest'
 import { renderHook, act } from '@testing-library/react'
-import { useContext, useState } from 'react'
+import React, { useContext, useState, ReactNode } from 'react'
 import { AuthContext } from '../../lib/context'
+
+interface WrapperProps {
+  children: ReactNode
+}
 
 describe('AuthContext', () => {
   it('should have correct default values', () => {
@@ -19,7 +23,7 @@ describe('AuthContext', () => {
   })
 
   it('should be usable with a custom provider', () => {
-    const wrapper = ({ children }) => {
+    const wrapper = ({ children }: WrapperProps) => {
       const [authEmail, setAuthEmail] = useState('custom@test.com')
       return (
         <AuthContext.Provider value={{ authEmail, setAuthEmail }}>
@@ -34,7 +38,7 @@ describe('AuthContext', () => {
   })
 
   it('should allow updating authEmail through provider', () => {
-    const wrapper = ({ children }) => {
+    const wrapper = ({ children }: WrapperProps) => {
       const [authEmail, setAuthEmail] = useState('')
       return (
         <AuthContext.Provider value={{ authEmail, setAuthEmail }}>

--- a/__tests__/lib/data.test.ts
+++ b/__tests__/lib/data.test.ts
@@ -1,6 +1,13 @@
 import { describe, it, expect } from 'vitest'
 import { UserData } from '../../lib/data'
 
+interface UserDataEntry {
+  id: number
+  year: number
+  userGain: number
+  userLoss: number
+}
+
 describe('UserData', () => {
   it('should be an array', () => {
     expect(Array.isArray(UserData)).toBe(true)
@@ -11,7 +18,7 @@ describe('UserData', () => {
   })
 
   it('should have correct structure for each entry', () => {
-    UserData.forEach((entry) => {
+    UserData.forEach((entry: UserDataEntry) => {
       expect(entry).toHaveProperty('id')
       expect(entry).toHaveProperty('year')
       expect(entry).toHaveProperty('userGain')
@@ -20,7 +27,7 @@ describe('UserData', () => {
   })
 
   it('should have numeric values for all properties', () => {
-    UserData.forEach((entry) => {
+    UserData.forEach((entry: UserDataEntry) => {
       expect(typeof entry.id).toBe('number')
       expect(typeof entry.year).toBe('number')
       expect(typeof entry.userGain).toBe('number')
@@ -29,23 +36,23 @@ describe('UserData', () => {
   })
 
   it('should have sequential IDs from 1 to 4', () => {
-    const ids = UserData.map((entry) => entry.id)
+    const ids = UserData.map((entry: UserDataEntry) => entry.id)
     expect(ids).toEqual([1, 2, 3, 4])
   })
 
   it('should have years from 2016 to 2019', () => {
-    const years = UserData.map((entry) => entry.year)
+    const years = UserData.map((entry: UserDataEntry) => entry.year)
     expect(years).toEqual([2016, 2017, 2018, 2019])
   })
 
   it('should have positive userGain values', () => {
-    UserData.forEach((entry) => {
+    UserData.forEach((entry: UserDataEntry) => {
       expect(entry.userGain).toBeGreaterThan(0)
     })
   })
 
   it('should have positive userLoss values', () => {
-    UserData.forEach((entry) => {
+    UserData.forEach((entry: UserDataEntry) => {
       expect(entry.userLoss).toBeGreaterThan(0)
     })
   })

--- a/__tests__/pages/Home.test.tsx
+++ b/__tests__/pages/Home.test.tsx
@@ -1,12 +1,13 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest'
+import React from 'react'
+import { describe, it, expect, vi, beforeEach, Mock } from 'vitest'
 import { render, screen, waitFor } from '@testing-library/react'
 
 vi.mock('next/head', () => ({
-  default: ({ children }) => <>{children}</>,
+  default: ({ children }: { children: React.ReactNode }) => <>{children}</>,
 }))
 
 vi.mock('next/image', () => ({
-  default: ({ src, alt, fill, priority, ...props }) => (
+  default: ({ src, alt, fill, priority, ...props }: { src: string; alt: string; fill?: boolean; priority?: boolean; [key: string]: unknown }) => (
     <img src={src} alt={alt} data-fill={fill} data-priority={priority} {...props} />
   ),
 }))
@@ -32,10 +33,12 @@ vi.mock('../../components/Footer', () => ({
 import Home from '../../pages/index'
 import Axios from 'axios'
 
+const mockedAxios = Axios as { get: Mock }
+
 describe('Home Page', () => {
   beforeEach(() => {
     vi.clearAllMocks()
-    Axios.get.mockResolvedValue({
+    mockedAxios.get.mockResolvedValue({
       data: { poster_path: '/test-poster.jpg' },
     })
   })
@@ -71,7 +74,7 @@ describe('Home Page', () => {
   it('should fetch poster from TMDB API on mount', async () => {
     render(<Home />)
     await waitFor(() => {
-      expect(Axios.get).toHaveBeenCalled()
+      expect(mockedAxios.get).toHaveBeenCalled()
     })
   })
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -25,6 +25,8 @@
       "devDependencies": {
         "@testing-library/jest-dom": "^6.9.1",
         "@testing-library/react": "^16.3.2",
+        "@types/node": "^25.2.3",
+        "@types/react": "^19.2.14",
         "@vitejs/plugin-react": "^5.1.3",
         "@vitest/coverage-v8": "^4.0.18",
         "autoprefixer": "^10.4.12",
@@ -33,6 +35,7 @@
         "jsdom": "^28.0.0",
         "postcss": "^8.4.18",
         "tailwindcss": "^3.2.1",
+        "typescript": "^5.9.3",
         "vitest": "^4.0.18"
       },
       "engines": {
@@ -3304,12 +3307,22 @@
       "license": "MIT"
     },
     "node_modules/@types/node": {
-      "version": "25.2.0",
-      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.0.tgz",
-      "integrity": "sha512-DZ8VwRFUNzuqJ5khrvwMXHmvPe+zGayJhr2CDNiKB1WBE1ST8Djl00D0IC4vvNmHMdj6DlbYRIaFE7WHjlDl5w==",
+      "version": "25.2.3",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-25.2.3.tgz",
+      "integrity": "sha512-m0jEgYlYz+mDJZ2+F4v8D1AyQb+QzsNqRuI7xg1VQX/KlKS0qT9r1Mo16yo5F/MtifXFgaofIFsdFMox2SxIbQ==",
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.16.0"
+      }
+    },
+    "node_modules/@types/react": {
+      "version": "19.2.14",
+      "resolved": "https://registry.npmjs.org/@types/react/-/react-19.2.14.tgz",
+      "integrity": "sha512-ilcTH/UniCkMdtexkoCN0bI7pMcJDvmQFPvuPvmEaYA/NSfFTAgdUSLAoVjaRJm7+6PvcM+q1zYOwS4wTYMF9w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "csstype": "^3.2.2"
       }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
@@ -4877,6 +4890,13 @@
       "engines": {
         "node": "20 || >=22"
       }
+    },
+    "node_modules/csstype": {
+      "version": "3.2.3",
+      "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
+      "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/damerau-levenshtein": {
       "version": "1.0.8",
@@ -9498,7 +9518,6 @@
       "integrity": "sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==",
       "dev": true,
       "license": "Apache-2.0",
-      "peer": true,
       "bin": {
         "tsc": "bin/tsc",
         "tsserver": "bin/tsserver"

--- a/package.json
+++ b/package.json
@@ -31,6 +31,8 @@
   "devDependencies": {
     "@testing-library/jest-dom": "^6.9.1",
     "@testing-library/react": "^16.3.2",
+    "@types/node": "^25.2.3",
+    "@types/react": "^19.2.14",
     "@vitejs/plugin-react": "^5.1.3",
     "@vitest/coverage-v8": "^4.0.18",
     "autoprefixer": "^10.4.12",
@@ -39,6 +41,7 @@
     "jsdom": "^28.0.0",
     "postcss": "^8.4.18",
     "tailwindcss": "^3.2.1",
+    "typescript": "^5.9.3",
     "vitest": "^4.0.18"
   }
 }

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,21 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "lib": ["DOM", "DOM.Iterable", "ESNext"],
+    "allowJs": true,
+    "skipLibCheck": true,
+    "strict": false,
+    "forceConsistentCasingInFileNames": true,
+    "noEmit": true,
+    "esModuleInterop": true,
+    "module": "ESNext",
+    "moduleResolution": "bundler",
+    "resolveJsonModule": true,
+    "isolatedModules": true,
+    "jsx": "react-jsx",
+    "incremental": true,
+    "types": ["vitest/globals", "@testing-library/jest-dom"]
+  },
+  "include": ["**/*.ts", "**/*.tsx", "__tests__/**/*"],
+  "exclude": ["node_modules"]
+}

--- a/vitest.config.js
+++ b/vitest.config.js
@@ -4,14 +4,16 @@ import react from '@vitejs/plugin-react'
 export default defineConfig({
   plugins: [react()],
   esbuild: {
-    loader: 'jsx',
-    include: /.*\.jsx?$/,
+    loader: 'tsx',
+    include: /\.[jt]sx?$/,
     exclude: [],
   },
   optimizeDeps: {
     esbuildOptions: {
       loader: {
         '.js': 'jsx',
+        '.ts': 'tsx',
+        '.tsx': 'tsx',
       },
     },
   },
@@ -19,7 +21,7 @@ export default defineConfig({
     environment: 'jsdom',
     globals: true,
     setupFiles: ['./vitest.setup.js'],
-    include: ['**/*.test.{js,jsx}'],
+    include: ['**/*.test.{js,jsx,ts,tsx}'],
     coverage: {
       reporter: ['text', 'json', 'html'],
     },


### PR DESCRIPTION
- Convert 12 test files from .js/.jsx to .ts/.tsx with proper type annotations
- Add TypeScript, @types/react, and @types/node dependencies
- Create tsconfig.json with react-jsx and vitest/testing-library types
- Update vitest.config.js to handle TypeScript and TSX files
- All 132 tests pass with TypeScript

https://claude.ai/code/session_01Rn7MSs85KHb65tnLdDnGe3